### PR TITLE
feat: add util that truncates domain name with max character length control

### DIFF
--- a/src/formatting/addresses.ts
+++ b/src/formatting/addresses.ts
@@ -3,11 +3,10 @@
  */
 
 export const truncateAddress = (address: string): string => {
-	return `${address.substring(0, 4)}...${address.substring(
-		address.length - 4,
+	return `${address?.substring(0, 4)}...${address?.substring(
+		address?.length - 4,
 	)}`;
 };
-
 
 /*
  * f: truncateDomain

--- a/src/formatting/addresses.ts
+++ b/src/formatting/addresses.ts
@@ -7,3 +7,22 @@ export const truncateAddress = (address: string): string => {
 		address.length - 4,
 	)}`;
 };
+
+
+/*
+ * f: truncateDomain
+ */
+
+export const truncateDomain = (
+	domainName: string,
+	maxCharacterLength: number,
+) => {
+	if (domainName?.length > maxCharacterLength) {
+		const splits = domainName.split('.');
+		if (splits?.length > 2) {
+			return `${splits[0]}...${splits[splits?.length - 1]}`;
+		}
+		return domainName;
+	}
+	return domainName;
+};


### PR DESCRIPTION
- add util that truncates a name with max character length control
- fix error (screenshot below)

Most of our modals will have a max container width at the largest breakpoint, meaning the max character length can be set to align with the container width for improved UI. 

<img width="786" alt="Screenshot 2022-10-21 at 16 58 07" src="https://user-images.githubusercontent.com/39112648/197238689-170c3d2a-93ec-428c-9f07-d12c9ed00a05.png">

<img width="786" alt="Screenshot 2022-10-21 at 16 58 16" src="https://user-images.githubusercontent.com/39112648/197238704-671c3f58-da54-4289-a8be-43e3ff857f97.png">

<img width="1439" alt="Screenshot 2022-10-24 at 23 47 19" src="https://user-images.githubusercontent.com/39112648/197644096-4f5c7d6e-8b43-4db3-8e45-d13bac5eb056.png">
