### PR TITLE
chore: bump minor `0.5.3` -> `0.5.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"repository": "git@github.com:zer0-os/zApp-utils.git",
 	"scripts": {
 		"clean": "rimraf dist && npx mkdirp dist",


### PR DESCRIPTION
bumping `0.5.3` to `0.5.4` to resolve publish error