### PR TITLE
chore: bump zui (`0.18.1`) and patch utils (`0.5.7`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@zero-tech/zapp-utils",
-			"version": "0.5.6",
+			"version": "0.5.7",
 			"license": "ISC",
 			"dependencies": {
 				"@cloudinary/url-gen": "^1.8.6",
@@ -49,7 +49,7 @@
 			},
 			"peerDependencies": {
 				"@testing-library/react": "^11.2.6",
-				"@zero-tech/zui": "^0.16.0",
+				"@zero-tech/zui": "^0.18.1",
 				"ethers": "^5.4.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
@@ -6869,9 +6869,9 @@
 			}
 		},
 		"node_modules/@zero-tech/zui": {
-			"version": "0.16.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.16.1.tgz",
-			"integrity": "sha512-c236KUX2UdRvFfFbE6KeJM1EgtKS6+zcszCY/Tv3xRpNqTNyV2Tp2+1HFptgkh4rn6YfW6p8KvDETzmuRnzF+w==",
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.18.1.tgz",
+			"integrity": "sha512-xjSWjYinjdCxJ6iPuxPdQvcUldFqiy2y7ThiMiiLyc6uOQx2S+hOvm5Q574kDvDaOv7vIZkOlbe5BFzNhzZx5Q==",
 			"peer": true,
 			"dependencies": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",
@@ -23865,9 +23865,9 @@
 			}
 		},
 		"@zero-tech/zui": {
-			"version": "0.16.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.16.1.tgz",
-			"integrity": "sha512-c236KUX2UdRvFfFbE6KeJM1EgtKS6+zcszCY/Tv3xRpNqTNyV2Tp2+1HFptgkh4rn6YfW6p8KvDETzmuRnzF+w==",
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.18.1.tgz",
+			"integrity": "sha512-xjSWjYinjdCxJ6iPuxPdQvcUldFqiy2y7ThiMiiLyc6uOQx2S+hOvm5Q574kDvDaOv7vIZkOlbe5BFzNhzZx5Q==",
 			"peer": true,
 			"requires": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"repository": "git@github.com:zer0-os/zApp-utils.git",
 	"scripts": {
 		"clean": "rimraf dist && npx mkdirp dist",
@@ -52,7 +52,7 @@
 	},
 	"peerDependencies": {
 		"@testing-library/react": "^11.2.6",
-		"@zero-tech/zui": "^0.16.0",
+		"@zero-tech/zui": "^0.18.1",
 		"ethers": "^5.4.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",


### PR DESCRIPTION
- bump `zui` version to latest (`0.18.1`)
- bump patch `zapp-utils` to (`0.5.7`)