### PR TITLE
chore: bump version (`0.5.7`) -> (`0.6.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.5.7",
+	"version": "0.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@zero-tech/zapp-utils",
-			"version": "0.5.7",
+			"version": "0.6.0",
 			"license": "ISC",
 			"dependencies": {
 				"@cloudinary/url-gen": "^1.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.5.7",
+	"version": "0.6.0",
 	"repository": "git@github.com:zer0-os/zApp-utils.git",
 	"scripts": {
 		"clean": "rimraf dist && npx mkdirp dist",

--- a/src/components/DynamicSizeWrapper/DynamicSizeWrapper.tsx
+++ b/src/components/DynamicSizeWrapper/DynamicSizeWrapper.tsx
@@ -1,0 +1,49 @@
+import { ReactNode, useEffect, useRef, useState } from 'react';
+
+//////////////////////////
+// Dynamic Size Wrapper //
+//////////////////////////
+
+export interface DynamicSizeWrapperProps {
+	className?: string;
+	children: ReactNode;
+}
+
+export const DynamicSizeWrapper = ({
+	className,
+	children,
+}: DynamicSizeWrapperProps) => {
+	const ref = useRef<HTMLDivElement>();
+	const [breakpoints, setBreakpoints] = useState<string | undefined>();
+
+	useEffect(() => {
+		if (!ref) {
+			return;
+		}
+
+		const resizeObserver = new ResizeObserver((event) => {
+			const width = event[0].contentBoxSize[0].inlineSize;
+			const breakpointWidths = Array.from(
+				{ length: Math.ceil(width / 50) },
+				(_, i) => i * 50,
+			);
+			setBreakpoints(breakpointWidths.join('-'));
+		});
+
+		resizeObserver.observe(ref.current);
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, [ref]);
+
+	return (
+		<div
+			className={className}
+			ref={ref}
+			data-container-breakpoints={breakpoints}
+		>
+			{children}
+		</div>
+	);
+};

--- a/src/components/DynamicSizeWrapper/index.ts
+++ b/src/components/DynamicSizeWrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './DynamicSizeWrapper';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
+export * from './DynamicSizeWrapper';
 export * from './IpfsMedia';
 export * from './ZAppContent';


### PR DESCRIPTION
- adds dynamic size wrapper 
- bumps version (`0.5.7`) -> (`0.6.0`)
- `npm i` to bump version no in `package-lock.json`