### PR TITLE
chore: bump version (`0.6.0`) -> (`0.6.1`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@zero-tech/zapp-utils",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"license": "ISC",
 			"dependencies": {
 				"@cloudinary/url-gen": "^1.8.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 			},
 			"peerDependencies": {
 				"@testing-library/react": "^11.2.6",
-				"@zero-tech/zui": "^0.18.1",
+				"@zero-tech/zui": "^0.20.1",
 				"ethers": "^5.4.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
@@ -6869,9 +6869,9 @@
 			}
 		},
 		"node_modules/@zero-tech/zui": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.18.1.tgz",
-			"integrity": "sha512-xjSWjYinjdCxJ6iPuxPdQvcUldFqiy2y7ThiMiiLyc6uOQx2S+hOvm5Q574kDvDaOv7vIZkOlbe5BFzNhzZx5Q==",
+			"version": "0.20.1",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.20.1.tgz",
+			"integrity": "sha512-O2Ib2Rr7pcey9+mQAUX4d1BpWgUjjL59R+z/3tkuj7ovAhWkauQXv7Egw+YhlIwQWa4G7WEOCfqtJgCtTWDoDA==",
 			"peer": true,
 			"dependencies": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",
@@ -23865,9 +23865,9 @@
 			}
 		},
 		"@zero-tech/zui": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.18.1.tgz",
-			"integrity": "sha512-xjSWjYinjdCxJ6iPuxPdQvcUldFqiy2y7ThiMiiLyc6uOQx2S+hOvm5Q574kDvDaOv7vIZkOlbe5BFzNhzZx5Q==",
+			"version": "0.20.1",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.20.1.tgz",
+			"integrity": "sha512-O2Ib2Rr7pcey9+mQAUX4d1BpWgUjjL59R+z/3tkuj7ovAhWkauQXv7Egw+YhlIwQWa4G7WEOCfqtJgCtTWDoDA==",
 			"peer": true,
 			"requires": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"repository": "git@github.com:zer0-os/zApp-utils.git",
 	"scripts": {
 		"clean": "rimraf dist && npx mkdirp dist",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	},
 	"peerDependencies": {
 		"@testing-library/react": "^11.2.6",
-		"@zero-tech/zui": "^0.18.1",
+		"@zero-tech/zui": "^0.20.1",
 		"ethers": "^5.4.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",


### PR DESCRIPTION
- bump zUI version (`0.18.1`) -> (`0.20.1`)
- bump Utils version (`0.6.0`) -> (`0.6.1`)