### PR TITLE
chore: bump version (`0.6.1`) -> (`0.6.2`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 			},
 			"peerDependencies": {
 				"@testing-library/react": "^11.2.6",
-				"@zero-tech/zui": "^0.20.1",
+				"@zero-tech/zui": "^0.21.0",
 				"ethers": "^5.4.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
@@ -6869,9 +6869,9 @@
 			}
 		},
 		"node_modules/@zero-tech/zui": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.20.1.tgz",
-			"integrity": "sha512-O2Ib2Rr7pcey9+mQAUX4d1BpWgUjjL59R+z/3tkuj7ovAhWkauQXv7Egw+YhlIwQWa4G7WEOCfqtJgCtTWDoDA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.21.0.tgz",
+			"integrity": "sha512-UYq/G1A8AVYRcGCWkNQRFOxD6ePZyxkDC++U+A0wCckcDsQ4dLsvz9VPBHDHg2tcB/6a4ccU+npkxYouJtY59g==",
 			"peer": true,
 			"dependencies": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",
@@ -23865,9 +23865,9 @@
 			}
 		},
 		"@zero-tech/zui": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.20.1.tgz",
-			"integrity": "sha512-O2Ib2Rr7pcey9+mQAUX4d1BpWgUjjL59R+z/3tkuj7ovAhWkauQXv7Egw+YhlIwQWa4G7WEOCfqtJgCtTWDoDA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.21.0.tgz",
+			"integrity": "sha512-UYq/G1A8AVYRcGCWkNQRFOxD6ePZyxkDC++U+A0wCckcDsQ4dLsvz9VPBHDHg2tcB/6a4ccU+npkxYouJtY59g==",
 			"peer": true,
 			"requires": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@zero-tech/zapp-utils",
-			"version": "0.6.1",
+			"version": "0.6.2",
 			"license": "ISC",
 			"dependencies": {
 				"@cloudinary/url-gen": "^1.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"repository": "git@github.com:zer0-os/zApp-utils.git",
 	"scripts": {
 		"clean": "rimraf dist && npx mkdirp dist",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	},
 	"peerDependencies": {
 		"@testing-library/react": "^11.2.6",
-		"@zero-tech/zui": "^0.20.1",
+		"@zero-tech/zui": "^0.21.0",
 		"ethers": "^5.4.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/src/components/IpfsMedia/IpfsMedia.tsx
+++ b/src/components/IpfsMedia/IpfsMedia.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../utils/cloudinary';
 import { getHashFromIpfsUrl } from '../../utils/ipfs';
 
+import { Video } from '@zero-tech/zui/components/Video';
 import { Image, ImageProps } from '@zero-tech/zui/components/Image';
 
 export interface IpfsMediaProps extends ImageProps {
@@ -74,12 +75,11 @@ export const IpfsMedia = ({
 			);
 		} else {
 			return (
-				<video
+				<Video
 					{...rest}
 					poster={getCloudinaryVideoPoster(hash)}
 					src={urls.video}
 					onError={() => setHasVideoFailed(true)}
-					controls={true}
 					autoPlay={true}
 					loop
 				/>


### PR DESCRIPTION
- chore: bump zui version (`0.20.2`) -> (`0.21.0`)
- feat: replace ipfs video tag with zui's video component for custom controls
- chore: bump utils version (`0.6.1`) -> (`0.6.2`)