### PR TITLE
chore: bump zui (`0.21.2`) and utils (`0.6.4`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@zero-tech/zapp-utils",
-			"version": "0.6.3",
+			"version": "0.6.4",
 			"license": "ISC",
 			"dependencies": {
 				"@cloudinary/url-gen": "^1.8.6",
@@ -49,7 +49,7 @@
 			},
 			"peerDependencies": {
 				"@testing-library/react": "^11.2.6",
-				"@zero-tech/zui": "^0.21.1",
+				"@zero-tech/zui": "^0.21.2",
 				"ethers": "^5.4.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
@@ -6869,9 +6869,9 @@
 			}
 		},
 		"node_modules/@zero-tech/zui": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.21.1.tgz",
-			"integrity": "sha512-hWUOYnpfzyvVrif5n/mbzIZdY86ZqqbX+1SgnRwiaFzoHmXyedECQvQtgdFXCluz9oCwAS2GoLL5J3U95PTo+A==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.21.2.tgz",
+			"integrity": "sha512-Z6+71Ra88jLuG7l8BTyF89E88Jt9aHsbW3JgCaOhiF1yWBGrhm+paCgKxHDlrFGI7qKxJarNW/UgXSW1wINgbw==",
 			"peer": true,
 			"dependencies": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",
@@ -23865,9 +23865,9 @@
 			}
 		},
 		"@zero-tech/zui": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.21.1.tgz",
-			"integrity": "sha512-hWUOYnpfzyvVrif5n/mbzIZdY86ZqqbX+1SgnRwiaFzoHmXyedECQvQtgdFXCluz9oCwAS2GoLL5J3U95PTo+A==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.21.2.tgz",
+			"integrity": "sha512-Z6+71Ra88jLuG7l8BTyF89E88Jt9aHsbW3JgCaOhiF1yWBGrhm+paCgKxHDlrFGI7qKxJarNW/UgXSW1wINgbw==",
 			"peer": true,
 			"requires": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-utils",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"repository": "git@github.com:zer0-os/zApp-utils.git",
 	"scripts": {
 		"clean": "rimraf dist && npx mkdirp dist",
@@ -52,7 +52,7 @@
 	},
 	"peerDependencies": {
 		"@testing-library/react": "^11.2.6",
-		"@zero-tech/zui": "^0.21.1",
+		"@zero-tech/zui": "^0.21.2",
 		"ethers": "^5.4.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",


### PR DESCRIPTION


- bump zUI (`0.21.1`) -> (`0.21.2`)
- bump utils version (`0.6.3`) -> (`0.6.4`) 