### PR TITLE
chore: add dependabot config for zui version automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    allow:
+      - dependency-name: '@zero-tech/zui'


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://wilderworld.atlassian.net/jira/software/c/projects/ZAP/boards/34?modal=detail&selectedIssue=ZAP-159)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- Build related changes

## 3. What is the old behaviour?
Manually maintain zUI version number as a peer dependency in zApp-Utils (which causes installation issues in zApp-NFTs)

## 4. What is the new behaviour?
Automated version number control for zui pacakge


